### PR TITLE
updated leap table 2020 expiration date

### DIFF
--- a/leap_table/leap_table.textpb
+++ b/leap_table/leap_table.textpb
@@ -26,6 +26,6 @@ positive_leaps: 2456109
 positive_leaps: 2457204
 positive_leaps: 2457754
 
-# This file has been updated through IERS Bulletin C Number 57.
+# This file has been updated through IERS Bulletin C Number 58.
 # https://www.iers.org/IERS/EN/Publications/Bulletins/bulletins.html
-end_jdn: 2458848
+end_jdn: 2459030


### PR DESCRIPTION
updated leap table 2020 expiration date

New Expiration:  2020-06-30