### PR TITLE
Update some of the unsmear code to use CHECK and LOG macros

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,6 +23,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":leap_table_cc_proto",
+        "@com_google_absl//absl/log",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,21 +2,23 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_skylib",
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
     ],
-    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
 )
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()
 
 http_archive(
     name = "com_google_absl",
-    sha256 = "91ac87d30cc6d79f9ab974c51874a704de9c2647c40f6932597329a282217ba8",  # SHARED_ABSL_SHA
-    strip_prefix = "abseil-cpp-20220623.1",
+    sha256 = "4d12bd14b5fc2fa912153dcadff1f23ef9dfe5c08e0607ec7a66689bdf41130d",  # SHARED_ABSL_SHA
+    strip_prefix = "abseil-cpp-20230117.rc1",
     urls = [
-        "https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.1.tar.gz",
+        "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230117.rc1.tar.gz",
     ],
 )
 

--- a/leap_table/BUILD.bazel
+++ b/leap_table/BUILD.bazel
@@ -27,6 +27,7 @@ cc_binary(
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/log:initialize",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",

--- a/leap_table/BUILD.bazel
+++ b/leap_table/BUILD.bazel
@@ -26,6 +26,8 @@ cc_binary(
         "//:unsmear",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:initialize",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
     ],

--- a/leap_table/leap_table_tool.cc
+++ b/leap_table/leap_table_tool.cc
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
   absl::InitializeLog();
 
   if (args.size() != 2) {
-    QLOG(FATAL) << kUsage;
+    LOG(QFATAL) << kUsage;
   }
   const auto& filename = args[1];
 
@@ -148,7 +148,7 @@ int main(int argc, char** argv) {
     }
     case Format::kJson:
     case Format::kDebug:
-      QLOG(FATAL) << "Unsupported --input";
+      LOG(QFATAL) << "Unsupported --input";
   }
 
   switch (absl::GetFlag(FLAGS_output)) {


### PR DESCRIPTION
The LTS version of the abseil library now contains logging functionality, so I updated our code to use LOG macros for logging and CHECK macros for early exits to be more similar to other Google code. I also updated some of our error messages to contain more information.

This change causes the exit codes of leap_table_tool to no longer mean anything, but I don't think anyone currently relies on the meaning of exit codes in that tool.